### PR TITLE
재고 동시성 테스트 코드 작성

### DIFF
--- a/api/src/test/java/com/example/api/domain/item/repository/StockConcurrencyTest.java
+++ b/api/src/test/java/com/example/api/domain/item/repository/StockConcurrencyTest.java
@@ -1,0 +1,52 @@
+package com.example.api.domain.item.repository;
+
+import com.example.core.domain.item.domain.Item;
+import com.example.core.domain.item.repository.ItemRepository;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+public class StockConcurrencyTest {
+
+    @Autowired
+    ItemRepository itemRepository;
+
+    @Test
+    @DisplayName("재고 필드 동시성 테스트")
+    @Disabled
+    public void testStockConcurrency() throws InterruptedException {
+        int threadCount = 100;
+
+        ExecutorService executorService = Executors.newFixedThreadPool(32);
+
+        CountDownLatch latch = new CountDownLatch(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            executorService.submit(() -> {
+                try {
+                    getDecreaseStock(1L);
+                } finally {
+                    latch.countDown();
+                }
+            });
+        }
+        latch.await();
+
+        Assertions.assertThat(itemRepository.findById(1L).get().getStock()).isEqualTo(0);
+    }
+
+    public void getDecreaseStock(Long itemId) {
+        Item item = itemRepository.findById(itemId).get();
+        item.decreaseStock();
+        itemRepository.save(item);
+    }
+}

--- a/core/src/main/java/com/example/core/domain/item/domain/Item.java
+++ b/core/src/main/java/com/example/core/domain/item/domain/Item.java
@@ -2,6 +2,7 @@ package com.example.core.domain.item.domain;
 
 import com.example.core.domain.common.BaseEntity;
 import com.example.core.domain.order.domain.Order;
+import com.example.core.exception.StockNegativeException;
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -48,6 +49,10 @@ public class Item extends BaseEntity {
     }
 
     public void decreaseStock() {
+        Long temp = this.stock;
+        if (temp < 1) {
+            throw new StockNegativeException();
+        }
         this.stock--;
     }
 }

--- a/core/src/main/java/com/example/core/exception/StockNegativeException.java
+++ b/core/src/main/java/com/example/core/exception/StockNegativeException.java
@@ -1,0 +1,13 @@
+package com.example.core.exception;
+
+public class StockNegativeException extends RuntimeException {
+
+    public StockNegativeException() {
+        this("해당 상품의 재고가 부족합니다.");
+    }
+
+    public StockNegativeException(String message) {
+        super(message);
+    }
+
+}


### PR DESCRIPTION
### 이슈 번호
- #15 

<br>

### 작업 내용
- [x] 재고 증가, 감소 테스트 코드 작성
- [x] 재고 동시성 테스트 코드 작성

<br>

### 동시성 문제 사진 
- 재고가 100개를 가진 아이템에 대하여 100번의 감소 로직 실행했는데 테스트 코드 실패하는 것을 확인했습니다. 

![image](https://github.com/wooyong99/item-order/assets/85385921/7946e56d-e395-4361-92d8-6b669890a955)

<br>

### 동시성 테스트 코드
```java
    @Test
    @DisplayName("재고 필드 동시성 테스트")
    public void testStockConcurrency() throws InterruptedException {
        // 아이템 1번 재고 수량 100개
        int threadCount = 100;

        ExecutorService executorService = Executors.newFixedThreadPool(32);

        CountDownLatch latch = new CountDownLatch(threadCount);

        for (int i = 0; i < threadCount; i++) {
            executorService.submit(() -> {
                try {
                    getDecreaseStock(1L);
                } finally {
                    latch.countDown();
                }
            });
        }
        latch.await();

        Assertions.assertThat(itemRepository.findById(1L).get().getStock()).isEqualTo(0);
    }

    // 재고 수량 감소 로직
    public void getDecreaseStock(Long itemId) {
        Item item = itemRepository.findById(itemId).get();
        item.decreaseStock();
        itemRepository.save(item);
    }
```