### PR TITLE
비관적 락을 이용하여 재고 동시성 이슈 해결

### DIFF
--- a/core/src/main/java/com/example/core/domain/item/repository/ItemRepository.java
+++ b/core/src/main/java/com/example/core/domain/item/repository/ItemRepository.java
@@ -1,7 +1,16 @@
 package com.example.core.domain.item.repository;
 
 import com.example.core.domain.item.domain.Item;
+import jakarta.persistence.LockModeType;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRepository {
+
+    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
+    @Query("select i from Item i where i.id = :itemId")
+    Optional<Item> findByIdWithPessimisticLock(@Param("itemId") Long itemId);
 }

--- a/order/src/main/java/com/example/api/domain/order/service/OrderService.java
+++ b/order/src/main/java/com/example/api/domain/order/service/OrderService.java
@@ -29,7 +29,7 @@ public class OrderService {
 
         User user = userRepository.findById(request.getUserId())
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 유저입니다."));
-        Item item = itemRepository.findById(itemId)
+        Item item = itemRepository.findByIdWithPessimisticLock(itemId)
             .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 상품입니다."));
 
         Order order = Order.builder()


### PR DESCRIPTION
### 이슈 번호
- #15 

<br>

### 작업 내용
- [x] `@Lock(LockModeType.PESSIMISTIC_WRITE)` 을 이용하여 동시성 이슈 해결
- [x] 테스트 코드 수정
- [x] 구현 코드 반영

<br>

### 테스트 코드 통과 
![image](https://github.com/wooyong99/item-order/assets/85385921/02770f28-980f-4e5e-af83-c0a7c6ead541)

<br>

### 고민했던 점
- 비관적 락 vs 낙관적 락
  - 낙관적 락이 비관적 락보다 성능적인 부분은 뛰어나다. 하지만 비관적 락을 선택한 이유는 **데이터의 일관성**과 **충돌 발생 가능성**이 빈번하다고 생각했기 때문이다. 
  또한 인기 상품의 경우 동시에 많은 요청이 발생할 수 있기 때문에 비관적 락을 적용하는게 좋다고 생각했다.
  
 #### 기존 코드

```java
private void getDecreaseStock(Long itemId) {
    Item item = itemRepository.findById(itemId).get();
    item.decreaseStock();
    itemRepository.save(item);
}
```

#### 개선 코드

```java
public interface ItemRepository extends JpaRepository<Item, Long>, ItemCustomRepository {
    @Lock(value = LockModeType.PESSIMISTIC_WRITE)
    @Query("select i from Item i where i.id = :itemId")
    Optional<Item> findByIdWithPessimisticLock(@Param("itemId") Long itemId);
}
```

```java
private void getDecreaseStock(Long itemId) {
    Item item = itemRepository.findByIdWithPessimisticLock(itemId).get();
    item.decreaseStock();
    itemRepository.save(item);
}
```